### PR TITLE
simple_logger_read fixes

### DIFF
--- a/lib/simple_logger/simple_logger.h
+++ b/lib/simple_logger/simple_logger.h
@@ -1,321 +1,58 @@
+#ifndef SIMPLE_LOGGER_H
+#define SIMPLE_LOGGER_H
 
 #include <stdint.h>
-#include <stdbool.h>
-#include "stdarg.h"
-#include "app_timer.h"
-#include "nrf_drv_clock.h"
 
-#include "simple_logger.h"
-#include "chanfs/ff.h"
-#include "chanfs/diskio.h"
+//////////////USAGE GUIDE////////////
+//	//REQUIRES: -
+//	//USES: -
+//
+//	//In initialization
+//	//permissions
+//	//"w" - write
+//	//"a" - append (just like c files)
+//	//"r" - read
+//	Example: simple_logger_init(filename, "a r");
+//	Note - the space is NECESSARY
+//	simple_logger_init(filename, permissions);
+//	
+//	//In main loop
+//	simple_logger_update()
+//
+//	//to create one time header in append mode (if the file exists, this won't append)
+//	simple_logger_log_header("%s,%d,%0f.2 This is a format string",...vars)
+//
+//	//to log data
+//	simple_logger_log("%s,%d,%f",...vars);
+//
+//	//currently supports final strings with substituted vars
+//	//of max length 256 chars
+//	//To have longer strings
+//	#define SIMPLE_LOGGER_BUFFER_SIZE N
+////////////////////////////////////
 
-static uint8_t simple_logger_inited = 0;
-static uint8_t simple_logger_file_exists = 0;
-static uint8_t header_written = 0;
-static uint8_t error_count = 0;
+enum {
+	SIMPLE_LOGGER_SUCCESS = 0,
+	SIMPLE_LOGGER_BUSY,
+	SIMPLE_LOGGER_BAD_FPOINTER,
+	SIMPLE_LOGGER_BAD_FPOINTER_INIT,
+	SIMPLE_LOGGER_BAD_CARD,
+	SIMPLE_LOGGER_BAD_CARD_INIT,
+	SIMPLE_LOGGER_FILE_EXISTS,
+	SIMPLE_LOGGER_FILE_ERROR,
+	SIMPLE_LOGGER_ALREADY_INITIALIZED,
+	SIMPLE_LOGGER_BAD_PERMISSIONS
+} SIMPLE_LOGGER_ERROR; 
 
-const char *file = NULL;
+uint8_t simple_logger_init(const char *filename, const char *permissions);
+uint8_t simple_logger_ready(void);
+void simple_logger_update();
+uint8_t simple_logger_power_on();
+uint8_t simple_logger_log(const char *format, ...)
+		__attribute__ ((format (printf, 1, 2)));
+uint8_t simple_logger_log_header(const char *format, ...)
+		__attribute__ ((format (printf, 1, 2)));
+uint8_t simple_logger_read(uint8_t* buf, uint8_t buf_len);
+uint8_t simple_logger_reset_fp();
 
-// Define your own buffer size if required; 256 used as default
-#ifndef SIMPLE_LOGGER_BUFFER_SIZE
-#define SIMPLE_LOGGER_BUFFER_SIZE	256
 #endif
-
-static char buffer[SIMPLE_LOGGER_BUFFER_SIZE];
-static char header_buffer[SIMPLE_LOGGER_BUFFER_SIZE];
-static uint32_t buffer_size = SIMPLE_LOGGER_BUFFER_SIZE;
-
-
-static FIL 		simple_logger_fpointer;	/* File object */
-uint32_t MAX_PTR;
-static FATFS 	simple_logger_fs;		/* Filesystem object */
-static uint8_t 	simple_logger_opts;
-static BYTE		work[FF_MAX_SS];		/* Work area (larger is better for processing time) */
-
-extern void disk_timerproc(void);
-extern void disk_restart(void);
-
-static void error(void) {
-
-	error_count++;
-
-	if(error_count > 20) {
-
-		disk_restart();
-		error_count = 0;
-	}
-}
-
-/*-----------------------------------------------------------------------*/
-/* Device timer function                                                 */
-/*-----------------------------------------------------------------------*/
-
-static void heartbeat (void* p_context) {
-	disk_timerproc();
-}
-
-APP_TIMER_DEF(clock_timer);
-
-// Function starting the internal LFCLK oscillator (used for RTC1 required by app_timer)
-// (When SoftDevice is enabled the LFCLK is always running and this is not needed).
-/*static void lfclk_request(void)
-{
-	uint32_t err_code = nrf_drv_clock_init();
-	APP_ERROR_CHECK(err_code);
-
-	nrf_drv_clock_lfclk_request(NULL);
-}*/
-
-static void timer_init(void (*timeout_fct)(void*)) {
-
-	// Request LFCLK if no SoftDevice is used
-	//lfclk_request();
-
-	// Init application timer module
-	ret_code_t err_code = app_timer_init();
-	APP_ERROR_CHECK(err_code);
-
-	// Create timer
-	err_code = app_timer_create(&clock_timer, APP_TIMER_MODE_REPEATED, timeout_fct);
-	APP_ERROR_CHECK(err_code);
-
-}
-
-static void timer_start(int period_ms) {
-
-	uint32_t err_code = app_timer_start(clock_timer, APP_TIMER_TICKS(period_ms), NULL);
-	APP_ERROR_CHECK(err_code);
-}
-
-/*static void timer_stop() {
-
-	uint32_t err_code = app_timer_stop(clock_timer);
-	APP_ERROR_CHECK(err_code);
-}*/
-
-/*-----------------------------------------------------------------------*/
-/* SD card function                                                		 */
-/*-----------------------------------------------------------------------*/
-
-static uint8_t logger_init();
-
-uint8_t simple_logger_init(const char *filename, const char *permissions) {
-
-	if(simple_logger_inited) {
-		return SIMPLE_LOGGER_ALREADY_INITIALIZED; // Can only initialize once
-	}
-
-	// Initialize a timer
-	timer_init(heartbeat);
-	timer_start(1);
-	
-	file = filename;
-
-	// We must have not timed out and a card is available
-	if((permissions[0] != 'w'  && permissions[0] != 'a') ||
-	   (permissions[1] != '\0' && permissions[2] != 'r') ) {
-		// We didn't set the right permissions
-		return SIMPLE_LOGGER_BAD_PERMISSIONS;
-	}
-
-	// Set write/append permissions
-	if(permissions[0] == 'w') {
-		simple_logger_opts = (FA_WRITE | FA_CREATE_ALWAYS);
-	} else if (permissions[0] == 'a'){
-		simple_logger_opts = (FA_WRITE | FA_OPEN_ALWAYS);
-	} else {
-		return SIMPLE_LOGGER_BAD_PERMISSIONS;
-	}
-
-	// Set read permission
-	if (permissions[1] == ',' && permissions[2] == 'r') {
-		simple_logger_opts |= FA_READ;
-	}
-
-	uint8_t err_code = logger_init();
-	return  err_code;
-}
-
-
-// An SD card was inserted after being gone for a bit
-// Let's reopen the file, and try to rewrite the header if it's necessary
-static uint8_t logger_init() {
-
-	volatile FRESULT res = FR_OK;
-	res |= f_mount(&simple_logger_fs, "", 1);
-
-	// See if the file system already exists
-	while (res != FR_OK) {
-		switch (res) {
-			case FR_NOT_READY: {
-				// No disk found; check "Card Detected" signal before calling this function
-				return res;
-			}
-			case FR_NO_FILESYSTEM: {
-				// No existing file system
-				res = f_mkfs("", FM_ANY, 0, work, sizeof(work));
-
-				if (res != FR_OK) {
-					printf("Failed to make a new filesystem: %d\n", res);
-					return res;
-				}
-
-				// Retry mounting now
-				res = f_mount(&simple_logger_fs, "", 1);
-				if (res != FR_OK) {
-					return res;
-				}
-
-				break;
-			}
-			default: {
-				printf("Unexpected error while mounting SD card: %d\n", res);
-				return res;
-			}
-		}
-	}
-
-	// See if the file already exists
-	FIL temp;
-	res |= f_open(&temp,file, FA_READ | FA_OPEN_EXISTING);
-
-	if(res == FR_NO_FILE) {
-
-		// The file doesn't exist
-		simple_logger_file_exists = 0;
-
-	} else if(res == FR_OK) {
-
-		// The file does exist
-		simple_logger_file_exists = 1;
-		res |= f_close(&temp);
-	}
-
-	res |= f_open(&simple_logger_fpointer,file, simple_logger_opts);
-
-	if(simple_logger_opts & FA_OPEN_ALWAYS) {
-		// We are in append mode and should move to the end
-		res |= f_lseek(&simple_logger_fpointer, f_size(&simple_logger_fpointer));
-	}
-
-	if(header_written && !simple_logger_file_exists) {
-		f_puts(header_buffer, &simple_logger_fpointer);
-		res |= f_sync(&simple_logger_fpointer);
-	}
-
-	simple_logger_inited = 1;
-	return res;
-}
-
-
-// Re-enable the SD card and initialize again
-uint8_t simple_logger_power_on() {
-	FRESULT res;
-
-	// Enable SD card
-	disk_enable();
-
-	// Re-initialize
-	res = logger_init();
-
-	return res;
-}
-
-
-uint8_t simple_logger_log_header(const char *format, ...) {
-
-	header_written = 1;
-
-	va_list argptr;
-	va_start(argptr, format);
-	vsnprintf(header_buffer, buffer_size, format, argptr);
-	va_end(argptr);
-
-	if(!simple_logger_file_exists) {
-
-		f_puts(header_buffer, &simple_logger_fpointer);
-		FRESULT res = f_sync(&simple_logger_fpointer);
-
-		if(res != FR_OK) {
-			res = logger_init();
-			if(res != FR_OK) {
-				error();
-			}
-			return res;
-		}
-
-		return res;
-	} else {
-		return SIMPLE_LOGGER_FILE_EXISTS;
-	}
-}
-
-
-// Log data
-uint8_t simple_logger_log(const char *format, ...) {
-
-	// ATTENTION: Make sure all strings are <= 255 bytes; the nRF SPI implementation does not allow longer transaction
-	// Note: This is due to the underlying DMA being restricted to 255 bytes; for more information, see https://devzone.nordicsemi.com/f/nordic-q-a/16580/send-more-than-255-bytes-by-spi-nrf52
-
-	va_list argptr;
-	va_start(argptr, format);
-	vsnprintf(buffer, buffer_size, format, argptr);
-	va_end(argptr);
-
-	f_puts(buffer, &simple_logger_fpointer);
-	FRESULT res = f_sync(&simple_logger_fpointer);
-
-	if(res != FR_OK) {
-		res = logger_init();
-		if(res == FR_OK) {
-			f_puts(buffer, &simple_logger_fpointer);
-			res = f_sync(&simple_logger_fpointer);
-		} else {
-			error();
-		}
-	}
-
-	return res;
-}
-
-// Read data
-uint8_t simple_logger_read(uint8_t* buf, uint8_t buf_len) {
-
-    // Buffer should be cleared before calling this function
-	UINT read_len = 0;
-	FRESULT res;
-
-	uint8_t cur_ptr = simple_logger_fpointer.fptr;
-	uint8_t nxt_ptr = cur_ptr+buf_len;
-	uint8_t to_read_buf_len = nxt_ptr < MAX_PTR ? buf_len : MAX_PTR - cur_ptr;
-
-	res = f_read(&simple_logger_fpointer, (void*)buf, to_read_buf_len, &read_len);
-
-	if (read_len < buf_len) {
-		// EOF
-		buf[read_len] = '\0';
-		return FR_INT_ERR;
-	}
-
-	if(res != FR_OK) {
-		printf("ERROR: Failed reading from SD card: %i\n", res);
-		error();
-	}
-
-	return res;
-}
-
-uint8_t simple_logger_reset_fp() {
-    // Sets the file pointer to the beginning of the file. Useful for reading from the beginning
-	FRESULT res = f_lseek(&simple_logger_fpointer, 0);
-
-	MAX_PTR = f_size(&simple_logger_fpointer);
-	// printf("\nmax_ptr: %d\n", MAX_PTR);
-
-	if(res != FR_OK) {
-		printf("ERROR: Failed reverting R/W pointer: %i\n", res);
-		error();
-	}
-
-	return res;
-}

--- a/lib/simple_logger/simple_logger.h
+++ b/lib/simple_logger/simple_logger.h
@@ -1,54 +1,321 @@
-#ifndef SIMPLE_LOGGER_H
-#define SIMPLE_LOGGER_H
 
 #include <stdint.h>
+#include <stdbool.h>
+#include "stdarg.h"
+#include "app_timer.h"
+#include "nrf_drv_clock.h"
 
-//////////////USAGE GUIDE////////////
-//	//REQUIRES: -
-//	//USES: -
-//
-//	//In initialization
-//	//permissions
-//	//"w" - write
-//	//"a" - append (just like c files)
-//	simple_logger_init(filename, permissions);
-//	
-//	//In main loop
-//	simple_logger_update()
-//
-//	//to create one time header in append mode (if the file exists, this won't append)
-//	simple_logger_log_header("%s,%d,%0f.2 This is a format string",...vars)
-//
-//	//to log data
-//	simple_logger_log("%s,%d,%f",...vars);
-//
-//	//currently supports final strings with substituted vars
-//	//of max length 256 chars
-//	//To have longer strings
-//	#define SIMPLE_LOGGER_BUFFER_SIZE N
-////////////////////////////////////
+#include "simple_logger.h"
+#include "chanfs/ff.h"
+#include "chanfs/diskio.h"
 
-enum {
-	SIMPLE_LOGGER_SUCCESS = 0,
-	SIMPLE_LOGGER_BUSY,
-	SIMPLE_LOGGER_BAD_FPOINTER,
-	SIMPLE_LOGGER_BAD_FPOINTER_INIT,
-	SIMPLE_LOGGER_BAD_CARD,
-	SIMPLE_LOGGER_BAD_CARD_INIT,
-	SIMPLE_LOGGER_FILE_EXISTS,
-	SIMPLE_LOGGER_FILE_ERROR,
-	SIMPLE_LOGGER_ALREADY_INITIALIZED,
-	SIMPLE_LOGGER_BAD_PERMISSIONS
-} SIMPLE_LOGGER_ERROR; 
+static uint8_t simple_logger_inited = 0;
+static uint8_t simple_logger_file_exists = 0;
+static uint8_t header_written = 0;
+static uint8_t error_count = 0;
 
-uint8_t simple_logger_init(const char *filename, const char *permissions);
-uint8_t simple_logger_ready(void);
-void simple_logger_update();
-uint8_t simple_logger_power_on();
-uint8_t simple_logger_log(const char *format, ...)
-		__attribute__ ((format (printf, 1, 2)));
-uint8_t simple_logger_log_header(const char *format, ...)
-		__attribute__ ((format (printf, 1, 2)));
-uint8_t simple_logger_read(uint8_t* buf, uint8_t buf_len);
+const char *file = NULL;
 
+// Define your own buffer size if required; 256 used as default
+#ifndef SIMPLE_LOGGER_BUFFER_SIZE
+#define SIMPLE_LOGGER_BUFFER_SIZE	256
 #endif
+
+static char buffer[SIMPLE_LOGGER_BUFFER_SIZE];
+static char header_buffer[SIMPLE_LOGGER_BUFFER_SIZE];
+static uint32_t buffer_size = SIMPLE_LOGGER_BUFFER_SIZE;
+
+
+static FIL 		simple_logger_fpointer;	/* File object */
+uint32_t MAX_PTR;
+static FATFS 	simple_logger_fs;		/* Filesystem object */
+static uint8_t 	simple_logger_opts;
+static BYTE		work[FF_MAX_SS];		/* Work area (larger is better for processing time) */
+
+extern void disk_timerproc(void);
+extern void disk_restart(void);
+
+static void error(void) {
+
+	error_count++;
+
+	if(error_count > 20) {
+
+		disk_restart();
+		error_count = 0;
+	}
+}
+
+/*-----------------------------------------------------------------------*/
+/* Device timer function                                                 */
+/*-----------------------------------------------------------------------*/
+
+static void heartbeat (void* p_context) {
+	disk_timerproc();
+}
+
+APP_TIMER_DEF(clock_timer);
+
+// Function starting the internal LFCLK oscillator (used for RTC1 required by app_timer)
+// (When SoftDevice is enabled the LFCLK is always running and this is not needed).
+/*static void lfclk_request(void)
+{
+	uint32_t err_code = nrf_drv_clock_init();
+	APP_ERROR_CHECK(err_code);
+
+	nrf_drv_clock_lfclk_request(NULL);
+}*/
+
+static void timer_init(void (*timeout_fct)(void*)) {
+
+	// Request LFCLK if no SoftDevice is used
+	//lfclk_request();
+
+	// Init application timer module
+	ret_code_t err_code = app_timer_init();
+	APP_ERROR_CHECK(err_code);
+
+	// Create timer
+	err_code = app_timer_create(&clock_timer, APP_TIMER_MODE_REPEATED, timeout_fct);
+	APP_ERROR_CHECK(err_code);
+
+}
+
+static void timer_start(int period_ms) {
+
+	uint32_t err_code = app_timer_start(clock_timer, APP_TIMER_TICKS(period_ms), NULL);
+	APP_ERROR_CHECK(err_code);
+}
+
+/*static void timer_stop() {
+
+	uint32_t err_code = app_timer_stop(clock_timer);
+	APP_ERROR_CHECK(err_code);
+}*/
+
+/*-----------------------------------------------------------------------*/
+/* SD card function                                                		 */
+/*-----------------------------------------------------------------------*/
+
+static uint8_t logger_init();
+
+uint8_t simple_logger_init(const char *filename, const char *permissions) {
+
+	if(simple_logger_inited) {
+		return SIMPLE_LOGGER_ALREADY_INITIALIZED; // Can only initialize once
+	}
+
+	// Initialize a timer
+	timer_init(heartbeat);
+	timer_start(1);
+	
+	file = filename;
+
+	// We must have not timed out and a card is available
+	if((permissions[0] != 'w'  && permissions[0] != 'a') ||
+	   (permissions[1] != '\0' && permissions[2] != 'r') ) {
+		// We didn't set the right permissions
+		return SIMPLE_LOGGER_BAD_PERMISSIONS;
+	}
+
+	// Set write/append permissions
+	if(permissions[0] == 'w') {
+		simple_logger_opts = (FA_WRITE | FA_CREATE_ALWAYS);
+	} else if (permissions[0] == 'a'){
+		simple_logger_opts = (FA_WRITE | FA_OPEN_ALWAYS);
+	} else {
+		return SIMPLE_LOGGER_BAD_PERMISSIONS;
+	}
+
+	// Set read permission
+	if (permissions[1] == ',' && permissions[2] == 'r') {
+		simple_logger_opts |= FA_READ;
+	}
+
+	uint8_t err_code = logger_init();
+	return  err_code;
+}
+
+
+// An SD card was inserted after being gone for a bit
+// Let's reopen the file, and try to rewrite the header if it's necessary
+static uint8_t logger_init() {
+
+	volatile FRESULT res = FR_OK;
+	res |= f_mount(&simple_logger_fs, "", 1);
+
+	// See if the file system already exists
+	while (res != FR_OK) {
+		switch (res) {
+			case FR_NOT_READY: {
+				// No disk found; check "Card Detected" signal before calling this function
+				return res;
+			}
+			case FR_NO_FILESYSTEM: {
+				// No existing file system
+				res = f_mkfs("", FM_ANY, 0, work, sizeof(work));
+
+				if (res != FR_OK) {
+					printf("Failed to make a new filesystem: %d\n", res);
+					return res;
+				}
+
+				// Retry mounting now
+				res = f_mount(&simple_logger_fs, "", 1);
+				if (res != FR_OK) {
+					return res;
+				}
+
+				break;
+			}
+			default: {
+				printf("Unexpected error while mounting SD card: %d\n", res);
+				return res;
+			}
+		}
+	}
+
+	// See if the file already exists
+	FIL temp;
+	res |= f_open(&temp,file, FA_READ | FA_OPEN_EXISTING);
+
+	if(res == FR_NO_FILE) {
+
+		// The file doesn't exist
+		simple_logger_file_exists = 0;
+
+	} else if(res == FR_OK) {
+
+		// The file does exist
+		simple_logger_file_exists = 1;
+		res |= f_close(&temp);
+	}
+
+	res |= f_open(&simple_logger_fpointer,file, simple_logger_opts);
+
+	if(simple_logger_opts & FA_OPEN_ALWAYS) {
+		// We are in append mode and should move to the end
+		res |= f_lseek(&simple_logger_fpointer, f_size(&simple_logger_fpointer));
+	}
+
+	if(header_written && !simple_logger_file_exists) {
+		f_puts(header_buffer, &simple_logger_fpointer);
+		res |= f_sync(&simple_logger_fpointer);
+	}
+
+	simple_logger_inited = 1;
+	return res;
+}
+
+
+// Re-enable the SD card and initialize again
+uint8_t simple_logger_power_on() {
+	FRESULT res;
+
+	// Enable SD card
+	disk_enable();
+
+	// Re-initialize
+	res = logger_init();
+
+	return res;
+}
+
+
+uint8_t simple_logger_log_header(const char *format, ...) {
+
+	header_written = 1;
+
+	va_list argptr;
+	va_start(argptr, format);
+	vsnprintf(header_buffer, buffer_size, format, argptr);
+	va_end(argptr);
+
+	if(!simple_logger_file_exists) {
+
+		f_puts(header_buffer, &simple_logger_fpointer);
+		FRESULT res = f_sync(&simple_logger_fpointer);
+
+		if(res != FR_OK) {
+			res = logger_init();
+			if(res != FR_OK) {
+				error();
+			}
+			return res;
+		}
+
+		return res;
+	} else {
+		return SIMPLE_LOGGER_FILE_EXISTS;
+	}
+}
+
+
+// Log data
+uint8_t simple_logger_log(const char *format, ...) {
+
+	// ATTENTION: Make sure all strings are <= 255 bytes; the nRF SPI implementation does not allow longer transaction
+	// Note: This is due to the underlying DMA being restricted to 255 bytes; for more information, see https://devzone.nordicsemi.com/f/nordic-q-a/16580/send-more-than-255-bytes-by-spi-nrf52
+
+	va_list argptr;
+	va_start(argptr, format);
+	vsnprintf(buffer, buffer_size, format, argptr);
+	va_end(argptr);
+
+	f_puts(buffer, &simple_logger_fpointer);
+	FRESULT res = f_sync(&simple_logger_fpointer);
+
+	if(res != FR_OK) {
+		res = logger_init();
+		if(res == FR_OK) {
+			f_puts(buffer, &simple_logger_fpointer);
+			res = f_sync(&simple_logger_fpointer);
+		} else {
+			error();
+		}
+	}
+
+	return res;
+}
+
+// Read data
+uint8_t simple_logger_read(uint8_t* buf, uint8_t buf_len) {
+
+    // Buffer should be cleared before calling this function
+	UINT read_len = 0;
+	FRESULT res;
+
+	uint8_t cur_ptr = simple_logger_fpointer.fptr;
+	uint8_t nxt_ptr = cur_ptr+buf_len;
+	uint8_t to_read_buf_len = nxt_ptr < MAX_PTR ? buf_len : MAX_PTR - cur_ptr;
+
+	res = f_read(&simple_logger_fpointer, (void*)buf, to_read_buf_len, &read_len);
+
+	if (read_len < buf_len) {
+		// EOF
+		buf[read_len] = '\0';
+		return FR_INT_ERR;
+	}
+
+	if(res != FR_OK) {
+		printf("ERROR: Failed reading from SD card: %i\n", res);
+		error();
+	}
+
+	return res;
+}
+
+uint8_t simple_logger_reset_fp() {
+    // Sets the file pointer to the beginning of the file. Useful for reading from the beginning
+	FRESULT res = f_lseek(&simple_logger_fpointer, 0);
+
+	MAX_PTR = f_size(&simple_logger_fpointer);
+	// printf("\nmax_ptr: %d\n", MAX_PTR);
+
+	if(res != FR_OK) {
+		printf("ERROR: Failed reverting R/W pointer: %i\n", res);
+		error();
+	}
+
+	return res;
+}


### PR DESCRIPTION
**`simple_logger`** did not have a proper read out functionality. Even though it does have a permission slot of **`read`**, because it had to be combined with either **`write`** or **`append`**, it was made useless, and the **`simple_logger_read`** function was near useless.

Case 1: Open the file in read write (**`"w r"`**) to clear all contents of a file and set the file pointer to the beginning of the file. The file is now empty and so any reads from this file pointer are useless.

Case 2: Open the file in read append (**`"a r"`**) to move the file pointer to the very end of the file while *preserving* all contents of the file. There is no functionality to move around the file pointer, so when trying to use **`simple_logger_read`**, the function simple moves the pointer back **`N`** bytes (where N is the length of the read out), and reads back the last **`N`** bytes of the file. Still pretty useless.

The new functionality added is the ability to move the file pointer to the beginning of the file using **`simple_logger_reset_fp()`**, and fixed the reads to *not* move back the file pointer before any read operations - this, however, does introduce a corner case where a user might want to read past the end of file. This is handled by checking the length of the file and comparing it to the calculated result of where the file pointer would end up, and gracefully handling such case by note attempting to read past the EOF. The read operation is still limited a certain buffer length (128 bytes), and any operation past that will not work.