### PR TITLE
Enable random RTT ports

### DIFF
--- a/make/Program.mk
+++ b/make/Program.mk
@@ -23,9 +23,13 @@ HW_VERSION ?= 52
 # Default port for GDB
 GDB_PORT_NUMBER ?= 2331
 
+# Pick a random port for each RTT session
+RAND_PORT_NUMBER := $(shell python3 -c 'from random import randint; print(randint(1023, 65535));' || echo '19021')
+
 # Configuration flags for JTAG tools
 JLINK_FLAGS = -device $(FULL_IC) -if swd -speed 4000
 JLINK_GDBSERVER_FLAGS = -port $(GDB_PORT_NUMBER)
+JLINK_RTT_PORT = -RTTTelnetPort $(RAND_PORT_NUMBER)
 
 # Configuration flags for nrfutil tools
 BOOTLOADER_DEV = /dev/ttyACM0
@@ -159,13 +163,13 @@ endif
 .PHONY: rtt
 rtt:
 ifeq ($(UNAME_S),Darwin)
-	$(Q)$(TERMINAL) "$(JLINK) $(JLINK_FLAGS) -AutoConnect 1"'
+	$(Q)$(TERMINAL) "$(JLINK) $(JLINK_FLAGS) $(JLINK_RTT_PORT) -AutoConnect 1"'
 	$(Q)sleep 1
-	$(Q)$(TERMINAL) "$(JLINK_RTTCLIENT)"'
+	$(Q)$(TERMINAL) "$(JLINK_RTTCLIENT) $(JLINK_RTT_PORT)"'
 else
-	$(Q)$(TERMINAL) -e "$(JLINK) $(JLINK_FLAGS) -AutoConnect 1"
+	$(Q)$(TERMINAL) -e "$(JLINK) $(JLINK_FLAGS) $(JLINK_RTT_PORT) -AutoConnect 1"
 	$(Q)sleep 1
-	$(Q)$(TERMINAL) -e "$(JLINK_RTTCLIENT)"
+	$(Q)$(TERMINAL) -e "$(JLINK_RTTCLIENT) $(JLINK_RTT_PORT)"
 endif
 
 # ---- nrfutil bootloader rules


### PR DESCRIPTION
For my class, I want to have multiple boards connected at once (wirelessly communicating with each other). This change opens RTT at a random port so I can have multiple sessions (one per board) open simultaneously automatically. It turns out the JTAG side has solved itself, and in newish versions of JLink tools, a popup asks you which board to interact with (by serial number) when multiple are connected. So with this change, when `make rtt` runs, it asks you which board to connect to and you can have two sessions active simultaneously.

Possible downside I wanted to run by you. This does use `python3` where I don't think it technically was required before. I don't think that's too onerous of a requirement though, and I set it up so that if python3 doesn't exist, RTT just uses the default port from before.