### PR TITLE
Allow starting RTT in Gnome session

### DIFF
--- a/make/Program.mk
+++ b/make/Program.mk
@@ -67,9 +67,12 @@ else
 	# Not in tmux
 	ifeq ($(UNAME_S),Darwin)
 		TERMINAL ?= osascript -e 'tell application "Terminal" to do script
-	else
-		TERMINAL ?= x-terminal-emulator -e
 	endif
+	# In Gnome session
+	ifeq ($(DESKTOP_SESSION),gnome)
+		TERMINAL ?= gnome-terminal
+	endif
+	TERMINAL ?= x-terminal-emulator -e
 endif
 
 # ---- ID FLASH LOCATION


### PR DESCRIPTION
When I ran `make rtt` on my machine, this didn't work because `x-terminal-emulator` was attempted to be started, which doesn't exist on Arch Linux. With this change, when inside of a Gnome session, a new `gnome-terminal` is created instead.